### PR TITLE
Removing redundant metadata; making span robust to NaN

### DIFF
--- a/buildings/power.py
+++ b/buildings/power.py
@@ -160,13 +160,8 @@ class ModelView:
         if (not r.ok):
             raise Exception ('getday request', r.status_code)
         df = Table.read_table(io.StringIO(r.text))
-        metadata = {'day'      : day,
-                    'sites'    : self.vsites,
-                    'classes'  : self.vclasses,
-                    }
-
         ts = df.select(['site', 'class', 'date', 't1', 't2', 't3', 't4', 'p_lo', 'p_hi'])
-        return TimeTable.from_table(ts, 'date'), metadata
+        return TimeTable.from_table(ts, 'date')
 
     def getdays(self, start_day, end_day):
         st = datetime.datetime.strptime(start_day,"%Y-%m-%d")
@@ -182,12 +177,8 @@ class ModelView:
         if (not r.ok):
             raise Exception ('getday request', r.status_code)
         df = Table.read_table(io.StringIO(r.text))
-        metadata = {'start'    : start_day,
-                    'end'      : end_day,
-                    'sites'    : self.vsites,
-                    'classes'  : self.vclasses}
         ts = df.select(['site', 'class', 'date', 't1', 't2', 't3', 't4', 'p_lo', 'p_hi'])
-        return TimeTable.from_table(ts, 'date'), metadata
+        return TimeTable.from_table(ts, 'date')
 
 
 class View:
@@ -293,5 +284,5 @@ if __name__ == '__main__':
 
     # model view
     mv = ucb.model(['Soda Hall New (as of 1/12/12)'], ['Building_Power_Demand_Sensor'])
-    model, md = mv.getdays('2020-03-07', '2020-03-14')
+    model = mv.getdays('2020-03-07', '2020-03-14')
     print(model)

--- a/buildings/timetable.py
+++ b/buildings/timetable.py
@@ -97,7 +97,12 @@ class TimeTable(Table):
             ftbl = self.copy()
         otimes = ftbl[self.time_column]
         for col in ftbl.categories :
-            f = interp1d(otimes, ftbl[col], fill_value = 'extrapolate')
+            # the interpolation function returned by 'interp1d' cannot use any NaN
+            # values. 'not_nan' contains the indexes of 'good' values; we use this
+            # to index into the X values (otimes) and Y values (ftbl[col]) so that
+            # interp1d only sees non-nan values
+            not_nan = np.where(np.isfinite(ftbl[col]))
+            f = interp1d(otimes[not_nan], ftbl[col][not_nan], fill_value = 'extrapolate')
             sttbl[col] = f(times)
         return sttbl
 


### PR DESCRIPTION
The metadata dict we were returning from ModelView was redundant with
the table returned by `CampusPower.metadata`. This changes the API:

```python
campus = CampusPower("...endpoint...")
# old
model, md = campus.model([building], ['Meter'])
# new
model = campus.model([building], ['Meter'])
```

---

In the implementation of `span`, the interpolation function returned by 'interp1d' cannot use any NaN values. I've changed `span` so that it only builds the interpolation function from non-NaN values. Seems to be working OK

